### PR TITLE
Fixed `instance method not found` warnings

### DIFF
--- a/Managed Objects/TSSTManagedGroup.m
+++ b/Managed Objects/TSSTManagedGroup.m
@@ -448,7 +448,7 @@
         return;
     }
     
-    password = [[NSApp delegate] passwordForArchiveWithPath: [self valueForKey: @"path"]];
+    password = [(SimpleComicAppDelegate *)[NSApp delegate] passwordForArchiveWithPath: [self valueForKey: @"path"]];
     [archive setPassword: password];
     
     [self setValue: password forKey: @"password"];

--- a/Session/TSSTPageView.m
+++ b/Session/TSSTPageView.m
@@ -249,7 +249,7 @@
 	{
 		NSArray * filePaths = [pboard propertyListForType: NSFilenamesPboardType];
         [sessionController updateSessionObject];
-		[[NSApp delegate] addFiles: filePaths toSession: [sessionController session]];
+		[(SimpleComicAppDelegate *)[NSApp delegate] addFiles: filePaths toSession: [sessionController session]];
 		return YES;
 	}
 	

--- a/Session/TSSTSessionWindowController.m
+++ b/Session/TSSTSessionWindowController.m
@@ -1298,7 +1298,7 @@ images are currently visible and then skips over them.
 
 - (NSManagedObjectContext *)managedObjectContext
 {
-    return [[NSApp delegate] managedObjectContext];
+    return [(SimpleComicAppDelegate *)[NSApp delegate] managedObjectContext];
 }
 
 


### PR DESCRIPTION
In a few places casting `[NSApp delegate]` to `(SimpleComicAppDelegate
*)` fixes the `instance method '...' not found (return type defaults to 'id')` warning.
