### PR TITLE
Added swipe to turn page

### DIFF
--- a/Session/TSSTPageView.m
+++ b/Session/TSSTPageView.m
@@ -826,7 +826,27 @@
 		NSPoint scrollPoint = NSMakePoint(NSMinX(visible) - ([theEvent deltaX] * 5), NSMinY(visible) + ([theEvent deltaY] * 5));
 		[self scrollPoint: scrollPoint];
 	}
-	
+
+    float deltaX = [theEvent deltaX];
+    if (deltaX != 0.0)
+    {
+        [theEvent trackSwipeEventWithOptions:NSEventSwipeTrackingLockDirection
+                    dampenAmountThresholdMin:-1.0
+                                         max:1.0
+                                usingHandler:^(CGFloat gestureAmount, NSEventPhase phase, BOOL isComplete, BOOL *stop) {
+                                }];
+    }
+
+
+    if (deltaX > 0.0)
+    {
+        [sessionController pageLeft: self];
+    }
+    else if (deltaX < 0.0)
+    {
+        [sessionController pageRight: self];
+    }
+
     [sessionController refreshLoupePanel];
 }
 


### PR DESCRIPTION
This is the same implementation added by @kapilreddy in PR #78 with the addition of a call to `-
trackSwipeEventWithOptions:dampenAmountThresholdMin:max:usingHandler:`. I noticed in the original implementation a single swipe would scroll through 3 or 4 pages. The addition of this new call will limit one page turn per swipe.

Thanks @kapilreddy for doing all of the initial work!
