### PR TITLE
Fix Loupe has gray corners in macOS 10.15 Catalina

### DIFF
--- a/English.lproj/TSSTSessionWindow.xib
+++ b/English.lproj/TSSTSessionWindow.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16B2657" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -25,8 +26,8 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="6" userLabel="Main Window">
-            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" unifiedTitleAndToolbar="YES"/>
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="6" userLabel="Main Window">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="40" y="225" width="460" height="529"/>
@@ -40,8 +41,8 @@
                         <rect key="frame" x="0.0" y="23" width="460" height="530"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" autoresizesSubviews="NO" copiesOnScroll="NO" id="KlA-W9-AWW">
-                            <rect key="frame" x="0.0" y="0.0" width="460" height="530"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <rect key="frame" x="0.0" y="0.0" width="445" height="515"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <customView id="235" customClass="TSSTPageView">
                                     <rect key="frame" x="0.0" y="0.0" width="135" height="65"/>
@@ -144,7 +145,7 @@
                         <nil key="toolTip"/>
                         <size key="minSize" width="59" height="25"/>
                         <size key="maxSize" width="59" height="25"/>
-                        <segmentedControl key="view" verticalHuggingPriority="750" misplaced="YES" id="521">
+                        <segmentedControl key="view" verticalHuggingPriority="750" id="521">
                             <rect key="frame" x="7" y="14" width="59" height="25"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <segmentedCell key="cell" borderStyle="border" alignment="left" style="texturedSquare" trackingMode="selectOne" id="522">
@@ -321,13 +322,13 @@
                 </subviews>
             </view>
         </window>
-        <window title="Panel" allowsToolTipsWhenApplicationIsInactive="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="363" userLabel="Loupe panel" customClass="TSSTInfoWindow">
+        <window title="Panel" allowsToolTipsWhenApplicationIsInactive="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="363" userLabel="Loupe panel" customClass="TSSTInfoWindow">
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="932" y="284" width="200" height="200"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <value key="minSize" type="size" width="175" height="107"/>
-            <view key="contentView" id="364">
+            <view key="contentView" id="364" customClass="TSSTOuterInfoView">
                 <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
@@ -338,6 +339,9 @@
                     </imageView>
                 </subviews>
             </view>
+            <connections>
+                <outlet property="outerView" destination="364" id="EuW-0V-UAQ"/>
+            </connections>
         </window>
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="373" userLabel="expose" customClass="TSSTKeyWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
@@ -365,7 +369,7 @@
             </connections>
         </window>
         <userDefaultsController id="403" userLabel="Shared Defaults"/>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="445" userLabel="Jump" customClass="NSPanel">
+        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="445" userLabel="Jump" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="468" width="229" height="42"/>
@@ -374,7 +378,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="229" height="42"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField verticalHuggingPriority="750" id="448">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="448">
                         <rect key="frame" x="50" y="10" width="41" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" state="on" borderStyle="bezel" title="9999" drawsBackground="YES" id="503">
@@ -385,7 +389,7 @@
                                 <real key="maximum" value="9999"/>
                             </numberFormatter>
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                         <connections>
@@ -393,7 +397,7 @@
                             <binding destination="12" name="maxValue" keyPath="arrangedObjects.@count" id="458"/>
                         </connections>
                     </textField>
-                    <textField verticalHuggingPriority="750" misplaced="YES" id="447">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="447">
                         <rect key="frame" x="7" y="10" width="39" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Page:" id="502">
@@ -434,7 +438,7 @@ Gw
             </view>
             <point key="canvasLocation" x="579" y="-347"/>
         </window>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="483" userLabel="Thumbnail" customClass="TSSTInfoWindow">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="483" userLabel="Thumbnail" customClass="TSSTInfoWindow">
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="160" width="350" height="350"/>

--- a/Progress Bar/TSSTInfoWindow.h
+++ b/Progress Bar/TSSTInfoWindow.h
@@ -8,12 +8,19 @@
 
 #import <Cocoa/Cocoa.h>
 
+@interface TSSTOuterInfoView : NSView {
+  float lastDiameter;
+}
+- (void)resizeToDiameter:(float)diameter;
+@end
 
 /*
  This panel subclass is used by both the loupe and the speach bubble styled
  page preview.
  */
-@interface TSSTInfoWindow : NSPanel { }
+@interface TSSTInfoWindow : NSPanel {
+  IBOutlet TSSTOuterInfoView *outerView;
+}
 
 - (void)caretAtPoint:(NSPoint)point size:(NSSize)size withLimitLeft:(float)left right:(float)right;
 - (void)centerAtPoint:(NSPoint)center;

--- a/Progress Bar/TSSTInfoWindow.m
+++ b/Progress Bar/TSSTInfoWindow.m
@@ -8,6 +8,7 @@
 
 #import "TSSTInfoWindow.h"
 #import "TSSTImageUtilities.h"
+#import <QuartzCore/CAShapeLayer.h>
 
 
 @implementation TSSTInfoWindow
@@ -45,6 +46,7 @@
 {
     NSRect frame = [self frame];
     [self setFrameOrigin: NSMakePoint(center.x - NSWidth(frame) / 2, center.y - NSHeight(frame) / 2)];
+    [outerView resizeToDiameter:frame.size.width];
 	[self invalidateShadow];
 }
 
@@ -57,8 +59,32 @@
 	[self setFrame: NSMakeRect(center.x - diameter / 2,  center.y - diameter / 2, diameter, diameter) 
 		   display: YES 
 		   animate: NO];
+  [outerView resizeToDiameter:diameter];
 }
 
+@end
+
+
+@implementation TSSTOuterInfoView
+
+- (void)awakeFromNib {
+  [super awakeFromNib];
+
+  CALayer *baseLayer = [[CALayer alloc] init];
+  baseLayer.backgroundColor = NSColor.clearColor.CGColor;
+  self.superview.layer = baseLayer;
+}
+
+- (void)resizeToDiameter:(float)diameter {
+  if (lastDiameter != diameter) {
+    CAShapeLayer *shapeLayer = [[CAShapeLayer alloc] init];
+    CGPathRef path = CGPathCreateWithEllipseInRect(NSMakeRect(0, 0, diameter, diameter), nil);
+    shapeLayer.path = path;
+    CGPathRelease(path);
+    self.superview.layer.mask = shapeLayer;
+    lastDiameter = diameter;
+  }
+}
 
 @end
 


### PR DESCRIPTION
This is a fix for https://github.com/arauchfuss/Simple-Comic/issues/124